### PR TITLE
fix battlefield obstacles

### DIFF
--- a/mods/dunes-terrain/content/config/dunes terrain/obstacles.json
+++ b/mods/dunes-terrain/content/config/dunes terrain/obstacles.json
@@ -90,156 +90,150 @@
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 2,
+		"height" : 1,
 		"blockedTiles" : [
 			0,
 			1
 		],
-		"animation" : "dunes/DnSkel1.def",
-		"absolute" : false
+		"animation" : "dunes/DnSkel1.def"
 	},
 	"dunesVase1" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 2,
+		"height" : 1,
 		"blockedTiles" : [
 			0,
 			1
 		],
-		"animation" : "dunes/DnVs1.def",
-		"absolute" : false
+		"animation" : "dunes/DnVs1.def"
 	},
 	"dunesVase2" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 2,
+		"height" : 1,
 		"blockedTiles" : [
 			0,
 			1
 		],
-		"animation" : "dunes/DnVs2.def",
-		"absolute" : false
+		"animation" : "dunes/DnVs2.def"
 	},
 	"dunesBones" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 3,
+		"height" : 2,
 		"blockedTiles" : [
 			0,
 			1,
 			2
 		],
-		"animation" : "dunes/DnBns1.def",
-		"absolute" : false
+		"animation" : "dunes/DnBns1.def"
 	},
 	"dunesRock1" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 3,
+		"height" : 2,
 		"blockedTiles" : [
 			0,
 			1,
 			2
 		],
 		"animation" : "dunes/DnRck1.def",
-		"absolute" : false
+		"foreground" : true
 	},
 	"dunesRock2" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 2,
+		"height" : 2,
 		"blockedTiles" : [
 			0,
 			1
 		],
 		"animation" : "dunes/DnRck2.def",
-		"absolute" : false
+		"foreground" : true
 	},
 	"dunesCactus1" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 3,
+		"width" : 2,
+		"height" : 2,
 		"blockedTiles" : [
 			0,
 			1
 		],
 		"animation" : "dunes/DnCct1.def",
-		"absolute" : false
+		"foreground" : true
 	},
 	"dunesCactus2" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
+		"width" : 2,
 		"height" : 4,
 		"blockedTiles" : [
-			0,
-			1
+			-16
 		],
 		"animation" : "dunes/DnCct2.def",
-		"absolute" : false
+		"foreground" : true
 	},
+	// this is a duplicate for some reason
 	"dunesCactus3" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
+		"width" : 2,
 		"height" : 4,
 		"blockedTiles" : [
-			0,
-			1
+			-16
 		],
 		"animation" : "dunes/DnCct2.def",
-		"absolute" : false
+		"foreground" : true
 	},
 	"dunesBush1" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 4,
+		"width" : 2,
+		"height" : 2,
 		"blockedTiles" : [
 			0,
 			1
 		],
 		"animation" : "dunes/DnBsh1.def",
-		"absolute" : false
+		"foreground" : true
 	},
 	"dunesBush2" : {
 		"allowedTerrains" : [
 			"dunes"
 		], //to change later
 		"specialBattlefields" : [],
-		"width" : 5,
-		"height" : 4,
+		"width" : 3,
+		"height" : 2,
 		"blockedTiles" : [
 			1,
 			-15,
-			-14
+			-16
 		],
-		"animation" : "dunes/DnBsh2.def",
-		"absolute" : false
+		"animation" : "dunes/DnBsh2.def"
 	}
 }


### PR DESCRIPTION
This PR addresses the battlefield obstacles. Most of them didn't match their visuals with their blocking area, so I fixed them. Below are comparisons before and after:

dunesBones:
<img width="500" height="268" alt="dunesBones" src="https://github.com/user-attachments/assets/9340f449-dd37-47e3-af19-c915a1768fc5" />

dunesBush1:
<img width="478" height="310" alt="dunesBush1" src="https://github.com/user-attachments/assets/ee5f05e2-f986-40d2-8256-994d9fad6341" />

dunesBush2:
<img width="522" height="310" alt="dunesBush2" src="https://github.com/user-attachments/assets/e6fb33ed-dc03-4452-a101-f58aeb11bdc1" />

dunesCactus1:
<img width="456" height="268" alt="dunesCactus1" src="https://github.com/user-attachments/assets/da7cc615-4fdd-4f3f-9db2-c453b6bf21b3" />

dunesCactus2 and 3 (same obstacle duplicated for some reason):
<img width="478" height="310" alt="dunesCactus2" src="https://github.com/user-attachments/assets/ea3087b1-c18c-4634-b6bb-ecb50f1494ec" />

dunesRock1:
<img width="500" height="268" alt="dunesRock1" src="https://github.com/user-attachments/assets/c1e3d50f-c315-41b2-a36d-9d88c246170a" />

dunesRock2:
<img width="456" height="268" alt="dunesRock2" src="https://github.com/user-attachments/assets/c5d0aacf-0e1a-4631-843f-f4cf59453430" />

dunesSkeleton:
<img width="434" height="268" alt="dunesSkeleton" src="https://github.com/user-attachments/assets/5b807d1e-c601-4398-8ec4-6ceee8eb332d" />

dunesVase1:
<img width="434" height="268" alt="dunesVase1" src="https://github.com/user-attachments/assets/79a3b24c-e396-4a4c-bcb9-044117123b00" />

dunesVase2:
<img width="434" height="268" alt="dunesVase2" src="https://github.com/user-attachments/assets/1b296d23-9f5b-439a-b012-a1b10a077067" />

This PR requires https://github.com/vcmi/vcmi/pull/7366 to properly function.